### PR TITLE
[FIX] base_report_to_printer:  add missing context to orm call

### DIFF
--- a/base_report_to_printer/static/src/js/qweb_action_manager.esm.js
+++ b/base_report_to_printer/static/src/js/qweb_action_manager.esm.js
@@ -12,11 +12,18 @@ async function cupsReportActionHandler(action, options, env) {
             [action.report_name]
         );
         if (print_action && print_action.action === "server") {
-            const result = await orm.call("ir.actions.report", "print_document", [
-                action.id,
-                action.context.active_ids,
-                action.data,
-            ]);
+            const result = await orm.call(
+                "ir.actions.report",
+                "print_document",
+                [
+                    action.id,
+                    action.context.active_ids,
+                    action.data,
+                ],
+                {
+                    context: action.context,
+                },
+            );
             if (result) {
                 env.services.notification.add(_t("Successfully sent to printer!"));
             } else {


### PR DESCRIPTION
Context should be passed to orm.call. This might be important if the target report is using a special report class to customize content of xml report based on context variables.